### PR TITLE
+ Reaction for hw home button

### DIFF
--- a/NativeAndroid/src/com/sbhave/nativeExtension/ui/CameraActivity.java
+++ b/NativeAndroid/src/com/sbhave/nativeExtension/ui/CameraActivity.java
@@ -146,7 +146,7 @@ public class CameraActivity extends Activity
 	@Override
 	public boolean onKeyDown(int keyCode, KeyEvent event)
 	{
-	    if ((keyCode == KeyEvent.KEYCODE_BACK))
+	    if ((keyCode == KeyEvent.KEYCODE_BACK) || (keyCode == KeyEvent.KEYCODE_HOME))
 	    {
 	    	freContext.setLaunched(false);
 	        finish();


### PR DESCRIPTION
When the camera activity is shown, pushing hw home button causes the application to minimize. When application is restored the camera activity is not shown but scanner.launched is true. Trying to reset or stop scanner or even dispose and reinitialise then launch fails.
I guess that adding the same reaction as for hw back should solve the problem.
